### PR TITLE
`gc_event_new`: add user-friendly `Date` & `Datetime` handling

### DIFF
--- a/R/gc_event_new.R
+++ b/R/gc_event_new.R
@@ -37,6 +37,18 @@
 gc_event_new <- function(x, start, end, ..., sendNotifications = FALSE,
                          verbose = TRUE) {
 
+  list2env(purrr::map(list(start = start, end = end), function(.x) {
+    if (is.list(.x)) {
+      .x
+    } else {
+      nm <- if (inherits(.x, "POSIXct"))
+        "dateTime"
+      else if (inherits(.x, "Date"))
+        "date"
+
+      rlang::list2(!!rlang::sym(nm) := lubridate::format_ISO8601(.x, usetz = TRUE))
+    }
+  }), environment())
   stopifnot(methods::is(x, "googlecalendar"),
             is.list(start), is.list(end))
 


### PR DESCRIPTION
This adds user-friendly enhancements to `gc_event_new` to convert Dates and Datetimes supplied as `start` and `end` to the list format accepted by the google calendar API